### PR TITLE
Babel & HTML 기본 개발환경 모듈 추가 및 세팅 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "@babel/preset-env"
+    ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
     "presets": [
-        "@babel/preset-env"
+        "@babel/preset-env", "@babel/preset-react"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
+    "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.5",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.5",
+    "html-loader": "^0.5.5",
+    "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "react-dom": "^16.8.3"
   },
   "devDependencies": {
+    "@babel/core": "^7.3.4",
+    "@babel/preset-env": "^7.3.4",
+    "babel-loader": "^8.0.5",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.1"

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+const App = () => {
+  return (
+    <div>
+      <p> React Here !</p>
+    </div>
+  );
+};
+
+export default App;
+
+ReactDOM.render(<App />, document.getElementById("app"));

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>React Setting</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-console.log('Hello World');
+import App from "./App";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: "babel-loader"
+                }
+            }
+        ]
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.js$/,
+                test: /\.(js|jsx)$/,
                 exclude: /node_modules/,
                 use: {
                     loader: "babel-loader"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,30 @@
+const HtmlWebPackPlugin = require("html-webpack-plugin");
+
 module.exports = {
-    module: {
-        rules: [
-            {
-                test: /\.(js|jsx)$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: "babel-loader"
-                }
-            }
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader"
+        }
+      },
+      {
+        test: /\.html$/,
+        use: [
+          {
+            loader: "html-loader",
+            options: { minimize: true }
+          }
         ]
-    }
-}
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebPackPlugin({
+      template: "./src/index.html",
+      filename: "./index.html"
+    })
+  ]
+};


### PR DESCRIPTION
두번 정도 추가 환경작업이 있을것같음. 추후로 css, 린트, 타입스크립트 환경 잡고 더 고도화할수있으면 고도화할 예정 

## 작업내역 
- babel 관련 모듈 추가
  - babel은 es6같은 최신 문법을 es5 이하 지원 브라우저에서도 사용할 수 있게 컴파일 할 때 코드를 변환시켜준다
  - `@babel/core`: 바벨 본체. 버전7 이후로 `babel`이 아닌 `@babel`을 네임스페이스로 활용하고 있다
  - `@babel/preset-env`: 지원하고자하는 브라우저의 범위를 지정하고 최신 문법을 쓸 수 있게 해주는 프리셋. ES버전을 따로 지정해주지 않아도 된다 
  - `@babel/preset-react`: React 사용을 위한 바벨 프리셋 
  - `babel-loader`: 바벨용 웹팩 로더 
- webpack 설정에 바벨 로더 추가 
  - webpack이  `.js`,`.jsx` 파일을 컴파일 할 때 바벨을 이용해 코드를 트랜스파일링하도록 함 
  - node_modules 폴더 내부에 있는 파일은 무시 
- html 관련 모듈 추가
  - `html-loader`: webpack 작업수행시 html을 문자열화하여 이미지 & CSS 정적 경로를 html 내에 선언. 
  - `html-webpack-plugin`:  webpack으로 번들링된 결과물을 서빙하는 html을 손쉽게 생성. body내의 `script`태그를 이용해 추가함 
- webpack 설정에 html 모듈 추가 
  - html-loader에 `minimize: true`를 옵션으로 줘서 html 파일 용량을 줄임 
  - html-webpack-plugin으로 하여금 `.src/index.html` 파일을 기반으로 dist 폴더 하위에 `index.html`이라는 이름의 최종 결과물을 생성하게끔 설정 (웹팩에서 번들링된 js파일 서빙) 
- 기본 html 코드 추가 
- 더미용 리액트 코드 추가 