### PR TITLE
Vue 기본 라우팅 기능 추가 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10758,6 +10758,11 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-router": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
+      "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "core-js": "^3.4.3",
-    "vue": "^2.6.10"
+    "vue": "^2.6.10",
+    "vue-router": "^3.1.3"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,11 @@
       "eslint:recommended",
       "plugin:prettier/recommended"
     ],
-    "rules": {},
+    "rules": {
+      "prettier/prettier": [
+        "warn"
+      ]
+    },
     "parserOptions": {
       "parser": "babel-eslint"
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,12 @@
 <template>
   <div id="app">
-    <IntroPage msg="Welcome to Your Vue.js App" />
+    <router-view></router-view>
   </div>
 </template>
 
 <script>
-import IntroPage from "./components/IntroPage.vue";
-
 export default {
-  name: "app",
-  components: {
-    IntroPage
-  }
+  name: "app"
 };
 </script>
 

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -2,7 +2,7 @@
   <div class="content">
     {{ msg }}
     <h1>나에게 가장 어울리는 수달은?</h1>
-    <button v-on:click="onclick">시작하기</button>
+    <router-link to="/quiz">quiz</router-link>
   </div>
 </template>
 
@@ -11,11 +11,6 @@ export default {
   name: "IntroPage",
   props: {
     msg: String
-  },
-  methods: {
-    onclick: function() {
-      let a = 1;
-    }
   }
 };
 </script>

--- a/src/components/QuizPage.vue
+++ b/src/components/QuizPage.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h1>Quiz Page</h1>
+    <router-link to="/result">결과 페이지</router-link>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "QuizPage"
+};
+</script>
+
+<style scoped></style>

--- a/src/components/ResultPage.vue
+++ b/src/components/ResultPage.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h1>Result Page</h1>
+    <router-link to="/">다시 하기</router-link>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "ResultPage"
+};
+</script>
+
+<style scoped></style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
-import Vue from 'vue'
-import App from './App.vue'
+import Vue from "vue";
+import App from "./App.vue";
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
 new Vue({
-  render: h => h(App),
-}).$mount('#app')
+  render: h => h(App)
+}).$mount("#app");

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,22 @@
 import Vue from "vue";
+import VueRouter from "vue-router";
 import App from "./App.vue";
+import IntroPage from "./components/IntroPage.vue";
+import QuizPage from "./components/QuizPage.vue";
+import ResultPage from "./components/ResultPage.vue";
 
 Vue.config.productionTip = false;
+Vue.use(VueRouter);
+
+const routes = [
+  { path: "/", component: IntroPage },
+  { path: "/quiz", component: QuizPage },
+  { path: "/result", component: ResultPage }
+];
+
+const router = new VueRouter({ routes });
 
 new Vue({
+  router,
   render: h => h(App)
 }).$mount("#app");


### PR DESCRIPTION
- vue-router 모듈 설치 및 세팅 
- 홈페이지 -> 퀴즈 -> 결과 -> 홈페이지 순으로 돌게끔 기본 라우팅 수정
- 프리티어 룰에 대한 위반은 에러가 아닌 경고 수준으로 낮춤 