### PR TITLE
사용자 선택에 따라 퀴즈 업데이트 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "rules": {
       "prettier/prettier": [
         "warn"
-      ]
+      ],
+      "no-console": 0
     },
     "parserOptions": {
       "parser": "babel-eslint"

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -2,7 +2,9 @@
   <div class="content">
     {{ msg }}
     <h1>나에게 가장 어울리는 수달은?</h1>
-    <router-link :to="{ name: 'quiz', params: { id: 1 } }">quiz</router-link>
+    <router-link :to="{ name: 'quiz', params: { initialID: 1 } }">
+      quiz
+    </router-link>
   </div>
 </template>
 

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -2,7 +2,7 @@
   <div class="content">
     {{ msg }}
     <h1>나에게 가장 어울리는 수달은?</h1>
-    <router-link to="/quiz">quiz</router-link>
+    <router-link :to="{ name: 'quiz', params: { id: 1 } }">quiz</router-link>
   </div>
 </template>
 

--- a/src/components/QuizPage.vue
+++ b/src/components/QuizPage.vue
@@ -1,13 +1,32 @@
 <template>
   <div>
     <h1>Quiz Page</h1>
+    <div class="quiz-box">
+      <p>{{ quiz }}</p>
+    </div>
+    <div class="anwser-box">
+      <p>{{ answer[0].msg }}</p>
+      <p>{{ answer[1].msg }}</p>
+    </div>
+
     <router-link to="/result">결과 페이지</router-link>
   </div>
 </template>
 
 <script>
+import quiz from "../data/quiz";
+
 export default {
-  name: "QuizPage"
+  name: "QuizPage",
+  props: ["id"],
+  computed: {
+    quiz: function() {
+      return quiz[this.id].quiz;
+    },
+    answer: function() {
+      return quiz[this.id].answer;
+    }
+  }
 };
 </script>
 

--- a/src/components/QuizPage.vue
+++ b/src/components/QuizPage.vue
@@ -5,11 +5,13 @@
       <p>{{ quiz }}</p>
     </div>
     <div class="anwser-box">
-      <p>{{ answer[0].msg }}</p>
-      <p>{{ answer[1].msg }}</p>
+      <button v-on:click="onClick('1')">
+        {{ answer[0].msg }}
+      </button>
+      <button v-on:click="onClick('2')">
+        {{ answer[1].msg }}
+      </button>
     </div>
-
-    <router-link to="/result">결과 페이지</router-link>
   </div>
 </template>
 
@@ -18,13 +20,30 @@ import quiz from "../data/quiz";
 
 export default {
   name: "QuizPage",
-  props: ["id"],
+  props: ["initialID"],
+  data: function() {
+    return {
+      id: this.initialID
+    };
+  },
   computed: {
     quiz: function() {
       return quiz[this.id].quiz;
     },
     answer: function() {
       return quiz[this.id].answer;
+    }
+  },
+  methods: {
+    onClick: function(idx) {
+      const next = this.id + idx;
+
+      if (!quiz[next]) {
+        console.log("결과 페이지로 이동");
+        // @TODO: 결과 페이지 이동
+      } else {
+        this.id = this.id + idx;
+      }
     }
   }
 };

--- a/src/data/quiz.js
+++ b/src/data/quiz.js
@@ -1,0 +1,261 @@
+import SUDAL from "./sudal";
+
+const quizResult = {
+  "1": {
+    quiz: "나는 요즘 ...",
+    answer: [
+      {
+        msg: "일상에서 당장 탈출하고 싶다.",
+        isLast: false
+      },
+      {
+        msg: "그럭저럭 잘 지낸다.",
+        isLast: false
+      }
+    ]
+  },
+  "11": {
+    quiz: "나는 ...",
+    answer: [
+      {
+        msg: "내 손으로 직접 탈출하겠다.",
+        isLast: false
+      },
+      {
+        msg: "잠시 쉬면 될 것 같다.",
+        isLast: false
+      }
+    ]
+  },
+  "12": {
+    quiz: "나는 사실 ...",
+    answer: [
+      {
+        msg: "심상치 않은 집중력의 소유자.",
+        isLast: false
+      },
+      {
+        msg: "딴짓 장인",
+        isLast: false
+      }
+    ]
+  },
+  "111": {
+    quiz: "나는 ...",
+    answer: [
+      {
+        msg: "먹고 마시면 된다.",
+        isLast: false
+      },
+      {
+        msg: "뭔가 다른 걸 해야겠다.",
+        isLast: false
+      }
+    ]
+  },
+  "112": {
+    quiz: "나는 ...",
+    answer: [
+      {
+        msg: "어딘가로 훌쩍 떠난다.",
+        isLast: false
+      },
+      {
+        msg: "어디를 가기는 또 귀찮다.",
+        isLast: false
+      }
+    ]
+  },
+  "121": {
+    quiz: "내 집중력은 ...",
+    answer: [
+      {
+        msg: "선천적으로 타고난 재능이다.",
+        isLast: false
+      },
+      {
+        msg: "고통을 통해 단련한 능력이다.",
+        isLast: false
+      }
+    ]
+  },
+  "122": {
+    quiz: "쉬는 날에는 ...",
+    answer: [
+      {
+        msg: "침대에서 나가기 싫다.",
+        isLast: false
+      },
+      {
+        msg: "나가서 안 놀면 억울하다.",
+        isLast: false
+      }
+    ]
+  },
+  "1111": {
+    quiz: "아무래도 ...",
+    answer: [
+      {
+        msg: "맛있는 음식을 먹어줘야지",
+        isLast: false
+      },
+      { msg: "술을 마셔줘야지.", isLast: true, result: SUDAL.MANCHI }
+    ]
+  },
+  "1112": {
+    quiz: "무언가를 ...",
+    answer: [
+      {
+        msg: "지르고 싶다.",
+        isLast: false
+      },
+      { msg: "찌르고 싶다.", isLast: true, result: SUDAL.KILLER }
+    ]
+  },
+  "1121": {
+    quiz: "휴가를 떠난다면 ...",
+    answer: [
+      {
+        msg: "계획적으로 쉴 것이다.",
+        isLast: true,
+        result: SUDAL.HUGA
+      },
+      { msg: "아 몰라 그냥 쉰다.", isLast: true, result: SUDAL.SPA }
+    ]
+  },
+  "1122": {
+    quiz: "나는 ...",
+    answer: [
+      {
+        msg: "도심 속 여유로운 카페가 좋다.",
+        isLast: true,
+        result: SUDAL.HEALING
+      },
+      { msg: "한적한 자연 그 자체가 좋다.", isLast: false }
+    ]
+  },
+  "1211": {
+    quiz: "나는 시련이 닥쳐도 ...",
+    answer: [
+      {
+        msg: "힘을 내서 극복한다.",
+        isLast: false
+      },
+      { msg: "흥이 넘쳐서 괜찮다.", isLast: true, result: SUDAL.DUMCHIT }
+    ]
+  },
+  "1212": {
+    quiz: "나는 평상시에 ...",
+    answer: [
+      {
+        msg: "내 자신을 단련한다.",
+        isLast: false
+      },
+      { msg: "내 통장을 단련한다.", isLast: true, result: SUDAL.JAETECH }
+    ]
+  },
+  "1221": {
+    quiz: "침대 위에서 ...",
+    answer: [
+      {
+        msg: "재미있는 동영상이나 본다.",
+        isLast: false
+      },
+      { msg: "뭐 보는 것도 지친다.", isLast: true, result: SUDAL.ANGYUNG }
+    ]
+  },
+  "1222": {
+    quiz: "나는 평소에 ...",
+    answer: [
+      {
+        msg: "사진을 많이 찍는다.",
+        isLast: true,
+        result: SUDAL.INSTA
+      },
+      { msg: "코인 노래방을 자주 가곤 한다.", isLast: false }
+    ]
+  },
+  "11111": {
+    quiz: "나는 음식을 ...",
+    answer: [
+      {
+        msg: "만들 줄 안다.",
+        isLast: true,
+        result: SUDAL.CHEF
+      },
+      { msg: "먹을 줄만 안다.", isLast: true, result: SUDAL.MIGAK }
+    ]
+  },
+  "11121": {
+    quiz: "이번에 새로 지른 물건을 ...",
+    answer: [
+      {
+        msg: "친구들에게 자랑하는 편이다.",
+        isLast: true,
+        result: SUDAL.HUSAE
+      },
+      { msg: "혼자 바라만 봐도 좋다.", isLast: true, result: SUDAL.JIRUM }
+    ]
+  },
+  "11222": {
+    quiz: "나는 자연 속에서 가끔 ...",
+    answer: [
+      {
+        msg: "깨달음을 얻는다.",
+        isLast: true,
+        result: SUDAL.HAE
+      },
+      { msg: "즐거움을 얻는다.", isLast: true, result: SUDAL.UBI }
+    ]
+  },
+  "12111": {
+    quiz: "나는 슬럼프가 오면 ...",
+    answer: [
+      {
+        msg: "차분하게 평정심을 유지한다.",
+        isLast: true,
+        result: SUDAL.SUNGSIL
+      },
+      { msg: "투지가 불타 오른다.", isLast: true, result: SUDAL.GUNSUNG }
+    ]
+  },
+  "12121": {
+    quiz: "내 생각에는 ...",
+    answer: [
+      {
+        msg: "건강한 육체에 건강한 정신이 깃든다.",
+        isLast: true,
+        result: SUDAL.UNDONG
+      },
+      { msg: "몸은 정신이 믿는대로 간다.", isLast: true, result: SUDAL.GOONGYE }
+    ]
+  },
+  "12211": {
+    quiz: "나는 ...",
+    answer: [
+      {
+        msg: "넷플릭스로 미드 챙겨 봐야지.",
+        isLast: true,
+        result: SUDAL.BOLGER
+      },
+      {
+        msg: "유튜브로 삘 꽂히는 거 봐야지.",
+        isLast: true,
+        result: SUDAL.DUTUCK
+      }
+    ]
+  },
+  "12222": {
+    quiz: "노래하면 당연히 ...",
+    answer: [
+      {
+        msg: "힙합!",
+        isLast: true,
+        result: SUDAL.SUWAG
+      },
+      { msg: "발라드~", isLast: true, result: SUDAL.MINSU }
+    ]
+  }
+};
+
+export default quizResult;

--- a/src/data/sudal.js
+++ b/src/data/sudal.js
@@ -1,0 +1,188 @@
+const SUDAL = {
+  SPA: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  INSTA: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  MIGAK: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  JIRUM: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  DUMCHIT: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  DUTUCK: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  GUNSUNG: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  UNDONG: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  SUNGSIL: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  MANCHI: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  HUSAE: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  GOONGYE: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  KILLER: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  SUWAG: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  MINSU: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  BOLGER: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  HUGA: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  HEALING: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  ANGYUNG: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  JAETECH: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  CHEF: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  HAE: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  },
+  UBI: {
+    keyword: [],
+    description: "",
+    creator: {
+      name: "",
+      note: ""
+    }
+  }
+};
+
+export default SUDAL;

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ Vue.use(VueRouter);
 
 const routes = [
   { path: "/", component: IntroPage },
-  { path: "/quiz", component: QuizPage },
+  { name: "quiz", path: "/quiz", component: QuizPage, props: true },
   { path: "/result", component: ResultPage }
 ];
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ const routes = [
   { path: "/result", component: ResultPage }
 ];
 
-const router = new VueRouter({ routes });
+const router = new VueRouter({ routes, mode: "history" });
 
 new Vue({
   router,

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ Vue.use(VueRouter);
 const routes = [
   { path: "/", component: IntroPage },
   { name: "quiz", path: "/quiz", component: QuizPage, props: true },
-  { path: "/result", component: ResultPage }
+  { name: "result", path: "/result", component: ResultPage, props: true }
 ];
 
 const router = new VueRouter({ routes, mode: "history" });


### PR DESCRIPTION
### 작업 내역

- 사용자 선택에 따라 퀴즈 선택지가 업데이트되도록 함
  - 상세 작업내역은 커밋 로그 참조 

### 배운 것

- history mode를 쓸 경우 url의 `#`은 지울 수 있지만 서버에서 별다른 설정을 못해줄 경우 중간 경로로 사용자 직접 유입시 404 에러가 뜨는 문제가 존재한다
- vue-router는 같은 컴포넌트에 대해서는 동작하지 않는다. 컴포넌트를 재사용하는 것이 이상적이기 때문이다.
- url에 표시하지 않고 param만 넘겨주고 싶다면 named router를 써야한다 
